### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Memory Store MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@divslingerx/mcp-server)](https://smithery.ai/server/@divslingerx/mcp-server)
+
 A Model Context Protocol (MCP) server that provides web search capabilities using Puppeteer.
 
 ## Features
@@ -11,6 +13,15 @@ A Model Context Protocol (MCP) server that provides web search capabilities usin
 
 ## Installation
 
+### Installing via Smithery
+
+To install Memory Store for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@divslingerx/mcp-server):
+
+```bash
+npx -y @smithery/cli install @divslingerx/mcp-server --client claude
+```
+
+### Installing Manually
 1. Clone the repository:
 
    ```bash

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - puppeteerExecutablePath
+    properties:
+      puppeteerExecutablePath:
+        type: string
+        description: Path to the Chromium executable for Puppeteer.
+      port:
+        type: number
+        default: 3000
+        description: Port on which the server will listen.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: ['dist/index.js'], env: { PUPPETEER_EXECUTABLE_PATH: config.puppeteerExecutablePath, PORT: config.port.toString() } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over SSE so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@divslingerx/mcp-server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂